### PR TITLE
Passthrough <video> props via HTMLProps

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/self-closing-comp */
 import React, {
-  HTMLAttributes,
+  HTMLProps,
   MutableRefObject,
   useEffect,
   useRef,
@@ -12,7 +12,7 @@ export type PlyrInstance = PlyrJS
 export type PlyrEvent = PlyrJSEvent
 export type PlyrCallback = (this: PlyrJS, event: PlyrEvent) => void
 
-export type PlyrProps = HTMLAttributes<HTMLVideoElement> & {
+export type PlyrProps = HTMLProps<HTMLVideoElement> & {
   source?: SourceInfo
   options?: Options
 }


### PR DESCRIPTION
Props like [`crossorigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin) (`crossOrigin`) will error


```
Property 'crossOrigin' does not exist on type 'IntrinsicAttributes & HTMLAttributes<HTMLVideoElement> & { source?: SourceInfo | undefined; options?: Options | undefined; } & RefAttributes<...>'.
    223 |         captions: { update: true, active: true },
    224 |       }}
  > 225 |       crossOrigin="anonymous"
        |       ^^^^^^^^^^^
    226 |     />    
```

To be honest, I'm not fully sure of the nuance between `HTMLProps` and `HTMLAttributes`, however switching to `HTMLProps` let me pass `crossOrigin` and other props without a warning. Also it enables completions inside and outside the component. That way, the component's `{...rest}` can truly behave as a pass through to [`<video>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video)

Ultimately - Never needed `crossorigin`, `Plyr` automatically appears to add `crossorigin`, where simply adding the attribute, even if empty, is equivalent to `crossorigin="anonymous"` ([link on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin))