### PR TITLE
fix: ensure imported css declared as side effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   },
   "license": "MIT",
   "author": "Chintan Prajapati",
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "exports": {
     "./package.json": "./package.json",
     "./plyr.css": "./plyr.css",


### PR DESCRIPTION
This resolves an issue when using `import "plyr-react/plyr.css"` where webpack would incorrectly detect that as an unused import and tree shake it away.

see https://github.com/gatsbyjs/gatsby/issues/19446 for context