### PR TITLE
Mark css files as side effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "license": "MIT",
   "author": "Chintan Prajapati",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
   "exports": {
     "./package.json": "./package.json",
     "./plyr.css": "./plyr.css",


### PR DESCRIPTION
Right now production build of parcel (and all other bundlers that take into account `sideEffects` flag) removes the `css` files completely from the bundle.

Specifying explicitly that css has side effects would solve the issue.